### PR TITLE
Fix ReflectionException: ...does not have a property named includeInheritedActions

### DIFF
--- a/src/DrupalContentTypeRegistry.php
+++ b/src/DrupalContentTypeRegistry.php
@@ -9,13 +9,14 @@ namespace Codeception\Module;
 use Codeception\Module\Drupal\ContentTypeRegistry\ContentType;
 use Codeception\Module\Drupal\ContentTypeRegistry\Fields\Field;
 use Codeception\Module\Drupal\ContentTypeRegistry\ContentTypeRegistryStorageInterface;
+use Codeception\Module;
 
 /**
  * Class DrupalContentTypeRegistry
  *
  * @package Codeception\Drupal
  */
-class DrupalContentTypeRegistry
+class DrupalContentTypeRegistry extends Module
 {
     /**
      * An array of ContentType objects.


### PR DESCRIPTION
I get an exception thrown if the module doesn't extend Codeception\Module