### PR TITLE
Changed getClassName to use the correctly capitalised value

### DIFF
--- a/src/Drupal/ContentTypeRegistry/EntityTypes/EntityType.php
+++ b/src/Drupal/ContentTypeRegistry/EntityTypes/EntityType.php
@@ -99,7 +99,7 @@ abstract class EntityType implements EntityTypeInterface
     protected static function getClassName($shortName)
     {
         if (isset(static::$entityTypes[$shortName])) {
-            return 'Codeception\\Module\\Drupal\\ContentTypeRegistry\\EntityTypes\\' . $shortName;
+            return 'Codeception\\Module\\Drupal\\ContentTypeRegistry\\EntityTypes\\' . static::$entityTypes[$shortName];
         } elseif (isset(static::$entityTypeAdditions[$shortName])) {
             return static::$entityTypeAdditions[$shortName];
         } else {


### PR DESCRIPTION
Changed getClassName to use the correctly capitalised value rather than than the shortname to load an EntityType subclass. This is necessary for case-sensitive systems.