### PR TITLE
Check for successful node creation missing after merge

### DIFF
--- a/src/DrupalContentTypeRegistry.php
+++ b/src/DrupalContentTypeRegistry.php
@@ -210,7 +210,11 @@ class DrupalContentTypeRegistry extends Module
             $title
         );
 
-        return $I->grabLastCreatedNid($I);
+        $nid = $I->grabLastCreatedNid($I);
+
+        $I->seeCreateNodeWasSuccessful($I, $msg, $nid);
+
+        return $nid;
     }
 
     /**


### PR DESCRIPTION
Hi,

It looks like there was an issue merging a couple of pull requests regarding createNode().

The first merge https://github.com/chriscohen/codeception-drupal-content-types/commit/d67a6535ca60bd54f6d6f3ec4e461cd1541415e3 added the seeCreateNodeWasSuccessful() function and called it in createNode(), but in the second commit https://github.com/chriscohen/codeception-drupal-content-types/commit/7aeda8f59ac150eaf5355f55edbf6c1eb23900ed the call to seeCreateNodeWasSuccessful()  was removed.

This means we're not able to override seeCreateNodeWasSuccessful(). Well, we can but it's never called.

This PR should put the call back in.

Thanks,
Andy.
