### PR TITLE
Fix fatal error if widget is not defined and selector is

### DIFF
--- a/src/Drupal/ContentTypeRegistry/Fields/Field.php
+++ b/src/Drupal/ContentTypeRegistry/Fields/Field.php
@@ -328,7 +328,7 @@ class Field
                 $field->setWidget(Widget::create($yaml, $field));
             }
         }
-        if (isset($yaml['selector'])) {
+        if (isset($yaml['selector']) && $field->getWidget()) {
             $field->getWidget()->setSelector($yaml['selector']);
         }
         if (isset($yaml['required']) && $yaml['required'] != 'false') {


### PR DESCRIPTION
Make sure the widget exists before calling setSelector()